### PR TITLE
Redesign layout with responsive grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,20 @@
     <head>
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, minimum-scale=1.0, maximum-scale=5.0" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, user-scalable=yes, minimum-scale=1.0, maximum-scale=5.0"
+        />
+        <meta
+            name="theme-color"
+            content="#ffffff"
+            media="(prefers-color-scheme: light)"
+        />
+        <meta
+            name="theme-color"
+            content="#1a1a1a"
+            media="(prefers-color-scheme: dark)"
+        />
         <title>계산기 - Blueaka Calculator</title>
         <meta name="description" content="확률 계산기 애플리케이션" />
     </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,12 @@
 import Calculator from './components/Calculator';
+import Layout from './components/Layout';
 
 const App = () => {
-    return <Calculator />;
+    return (
+        <Layout>
+            <Calculator />
+        </Layout>
+    );
 };
 
 export default App;

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -477,9 +477,10 @@ const Calculator: React.FC = () => {
                 `물건 ${index + 1}: ${obj.w}x${obj.h} ${obj.totalCount}개`
               ).join(', ')}
             </div>
-          </div>          <div className="flex flex-col gap-4 sm:gap-6">
+          </div>
+          <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
             {/* Main content - object placement and game grid */}
-            <div>
+            <div className="space-y-6">
               <div className="mb-4 sm:mb-6">
                 <Label className="text-base sm:text-lg font-semibold mb-2 block">
                   찾은 물건 배치
@@ -631,12 +632,13 @@ const Calculator: React.FC = () => {
                   </div>
                 </div>
               </div>
-            </div>            {/* Probability Results - moved below the game grid, title removed */}
-            <div>
+            {/* Probability Results */}
+            <div className="space-y-6 lg:sticky lg:top-24">
               <div className="overflow-x-auto custom-scrollbar prevent-horizontal-scroll">
-                <div className="grid grid-cols-9 gap-0.5 w-fit min-w-[270px] xs:min-w-[240px] mx-auto sm:mx-0">
+                <div className="grid grid-cols-9 gap-0.5 w-fit min-w-[270px] xs:min-w-[240px] mx-auto">
                   {Array.from({ length: GRID_HEIGHT }, (_, y) =>
-                    Array.from({ length: GRID_WIDTH }, (_, x) => (                      <div
+                    Array.from({ length: GRID_WIDTH }, (_, x) => (
+                      <div
                         key={`result-${x}-${y}`}
                         className={getCellClassName(x, y, true)}
                         style={getCellStyles(x, y)}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,7 @@
+const Footer = () => (
+    <footer className="border-t py-3 text-center text-xs text-muted-foreground">
+        © 2025 Blueaka Calculator
+    </footer>
+);
+
+export default Footer;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,31 @@
+import { Sun, Moon } from 'lucide-react';
+import { Button } from './ui/button';
+import { useTheme } from '@/hooks/useTheme';
+
+const Header = () => {
+    const { theme, toggleTheme } = useTheme();
+
+    return (
+        <header className="app-header sticky top-0 z-10 w-full border-b">
+            <div className="mx-auto flex max-w-6xl items-center justify-between px-3 py-2 sm:py-3">
+                <h1 className="text-lg font-semibold sm:text-2xl">
+                    Blueaka Calculator
+                </h1>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={toggleTheme}
+                    aria-label="Toggle theme"
+                >
+                    {theme === 'dark' ? (
+                        <Sun className="size-5" />
+                    ) : (
+                        <Moon className="size-5" />
+                    )}
+                </Button>
+            </div>
+        </header>
+    );
+};
+
+export default Header;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+
+interface LayoutProps {
+    children: ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+    return (
+        <div className="flex min-h-screen flex-col bg-background text-foreground">
+            <Header />
+            <main className="flex-1 p-2 sm:p-4">{children}</main>
+            <Footer />
+        </div>
+    );
+};
+
+export default Layout;

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export const useTheme = () => {
+    const [theme, setTheme] = useState<Theme>(() => {
+        if (typeof window === 'undefined') return 'light';
+        const stored = localStorage.getItem('theme') as Theme | null;
+        if (stored) return stored;
+        const prefersDark = window.matchMedia(
+            '(prefers-color-scheme: dark)'
+        ).matches;
+        return prefersDark ? 'dark' : 'light';
+    });
+
+    useEffect(() => {
+        const root = document.documentElement;
+        if (theme === 'dark') {
+            root.classList.add('dark');
+        } else {
+            root.classList.remove('dark');
+        }
+        localStorage.setItem('theme', theme);
+    }, [theme]);
+
+    const toggleTheme = () =>
+        setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+    return { theme, toggleTheme };
+};

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@ layer(base);
 
 @import 'tailwindcss';
 
-@import "tw-animate-css";
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -25,6 +25,7 @@ layer(base);
             'Segoe UI Emoji',
             'Segoe UI Symbol',
             'Noto Color Emoji';
+        scroll-behavior: smooth;
     }
 
     @font-face {
@@ -34,216 +35,118 @@ layer(base);
 }
 
 @theme inline {
-    --radius-sm:
-            calc(var(--radius) - 4px);
-    --radius-md:
-            calc(var(--radius) - 2px);
-    --radius-lg:
-            var(--radius);
-    --radius-xl:
-            calc(var(--radius) + 4px);
-    --color-background:
-            var(--background);
-    --color-foreground:
-            var(--foreground);
-    --color-card:
-            var(--card);
-    --color-card-foreground:
-            var(--card-foreground);
-    --color-popover:
-            var(--popover);
-    --color-popover-foreground:
-            var(--popover-foreground);
-    --color-primary:
-            var(--primary);
-    --color-primary-foreground:
-            var(--primary-foreground);
-    --color-secondary:
-            var(--secondary);
-    --color-secondary-foreground:
-            var(--secondary-foreground);
-    --color-muted:
-            var(--muted);
-    --color-muted-foreground:
-            var(--muted-foreground);
-    --color-accent:
-            var(--accent);
-    --color-accent-foreground:
-            var(--accent-foreground);
-    --color-destructive:
-            var(--destructive);
-    --color-border:
-            var(--border);
-    --color-input:
-            var(--input);
-    --color-ring:
-            var(--ring);
-    --color-chart-1:
-            var(--chart-1);
-    --color-chart-2:
-            var(--chart-2);
-    --color-chart-3:
-            var(--chart-3);
-    --color-chart-4:
-            var(--chart-4);
-    --color-chart-5:
-            var(--chart-5);
-    --color-sidebar:
-            var(--sidebar);
-    --color-sidebar-foreground:
-            var(--sidebar-foreground);
-    --color-sidebar-primary:
-            var(--sidebar-primary);
-    --color-sidebar-primary-foreground:
-            var(--sidebar-primary-foreground);
-    --color-sidebar-accent:
-            var(--sidebar-accent);
-    --color-sidebar-accent-foreground:
-            var(--sidebar-accent-foreground);
-    --color-sidebar-border:
-            var(--sidebar-border);
-    --color-sidebar-ring:
-            var(--sidebar-ring);
+    --radius-sm: calc(var(--radius) - 4px);
+    --radius-md: calc(var(--radius) - 2px);
+    --radius-lg: var(--radius);
+    --radius-xl: calc(var(--radius) + 4px);
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-destructive: var(--destructive);
+    --color-border: var(--border);
+    --color-input: var(--input);
+    --color-ring: var(--ring);
+    --color-chart-1: var(--chart-1);
+    --color-chart-2: var(--chart-2);
+    --color-chart-3: var(--chart-3);
+    --color-chart-4: var(--chart-4);
+    --color-chart-5: var(--chart-5);
+    --color-sidebar: var(--sidebar);
+    --color-sidebar-foreground: var(--sidebar-foreground);
+    --color-sidebar-primary: var(--sidebar-primary);
+    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+    --color-sidebar-accent: var(--sidebar-accent);
+    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+    --color-sidebar-border: var(--sidebar-border);
+    --color-sidebar-ring: var(--sidebar-ring);
 }
 
 :root {
-    --radius:
-            0.625rem;
-    --background:
-            oklch(1 0 0);
-    --foreground:
-            oklch(0.145 0 0);
-    --card:
-            oklch(1 0 0);
-    --card-foreground:
-            oklch(0.145 0 0);
-    --popover:
-            oklch(1 0 0);
-    --popover-foreground:
-            oklch(0.145 0 0);
-    --primary:
-            oklch(0.205 0 0);
-    --primary-foreground:
-            oklch(0.985 0 0);
-    --secondary:
-            oklch(0.97 0 0);
-    --secondary-foreground:
-            oklch(0.205 0 0);
-    --muted:
-            oklch(0.97 0 0);
-    --muted-foreground:
-            oklch(0.556 0 0);
-    --accent:
-            oklch(0.97 0 0);
-    --accent-foreground:
-            oklch(0.205 0 0);
-    --destructive:
-            oklch(0.577 0.245 27.325);
-    --border:
-            oklch(0.922 0 0);
-    --input:
-            oklch(0.922 0 0);
-    --ring:
-            oklch(0.708 0 0);
-    --chart-1:
-            oklch(0.646 0.222 41.116);
-    --chart-2:
-            oklch(0.6 0.118 184.704);
-    --chart-3:
-            oklch(0.398 0.07 227.392);
-    --chart-4:
-            oklch(0.828 0.189 84.429);
-    --chart-5:
-            oklch(0.769 0.188 70.08);
-    --sidebar:
-            oklch(0.985 0 0);
-    --sidebar-foreground:
-            oklch(0.145 0 0);
-    --sidebar-primary:
-            oklch(0.205 0 0);
-    --sidebar-primary-foreground:
-            oklch(0.985 0 0);
-    --sidebar-accent:
-            oklch(0.97 0 0);
-    --sidebar-accent-foreground:
-            oklch(0.205 0 0);
-    --sidebar-border:
-            oklch(0.922 0 0);
-    --sidebar-ring:
-            oklch(0.708 0 0);
+    --radius: 0.625rem;
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --chart-1: oklch(0.646 0.222 41.116);
+    --chart-2: oklch(0.6 0.118 184.704);
+    --chart-3: oklch(0.398 0.07 227.392);
+    --chart-4: oklch(0.828 0.189 84.429);
+    --chart-5: oklch(0.769 0.188 70.08);
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    --background:
-            oklch(0.145 0 0);
-    --foreground:
-            oklch(0.985 0 0);
-    --card:
-            oklch(0.205 0 0);
-    --card-foreground:
-            oklch(0.985 0 0);
-    --popover:
-            oklch(0.205 0 0);
-    --popover-foreground:
-            oklch(0.985 0 0);
-    --primary:
-            oklch(0.922 0 0);
-    --primary-foreground:
-            oklch(0.205 0 0);
-    --secondary:
-            oklch(0.269 0 0);
-    --secondary-foreground:
-            oklch(0.985 0 0);
-    --muted:
-            oklch(0.269 0 0);
-    --muted-foreground:
-            oklch(0.708 0 0);
-    --accent:
-            oklch(0.269 0 0);
-    --accent-foreground:
-            oklch(0.985 0 0);
-    --destructive:
-            oklch(0.704 0.191 22.216);
-    --border:
-            oklch(1 0 0 / 10%);
-    --input:
-            oklch(1 0 0 / 15%);
-    --ring:
-            oklch(0.556 0 0);
-    --chart-1:
-            oklch(0.488 0.243 264.376);
-    --chart-2:
-            oklch(0.696 0.17 162.48);
-    --chart-3:
-            oklch(0.769 0.188 70.08);
-    --chart-4:
-            oklch(0.627 0.265 303.9);
-    --chart-5:
-            oklch(0.645 0.246 16.439);
-    --sidebar:
-            oklch(0.205 0 0);
-    --sidebar-foreground:
-            oklch(0.985 0 0);
-    --sidebar-primary:
-            oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground:
-            oklch(0.985 0 0);
-    --sidebar-accent:
-            oklch(0.269 0 0);
-    --sidebar-accent-foreground:
-            oklch(0.985 0 0);
-    --sidebar-border:
-            oklch(1 0 0 / 10%);
-    --sidebar-ring:
-            oklch(0.556 0 0);
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+    --chart-1: oklch(0.488 0.243 264.376);
+    --chart-2: oklch(0.696 0.17 162.48);
+    --chart-3: oklch(0.769 0.188 70.08);
+    --chart-4: oklch(0.627 0.265 303.9);
+    --chart-5: oklch(0.645 0.246 16.439);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {
-  * {
-    @apply border-border outline-ring/50;
+    * {
+        @apply border-border outline-ring/50;
     }
-  body {
-    @apply bg-background text-foreground;
+    body {
+        @apply bg-background text-foreground;
     }
 }
 
@@ -251,28 +154,62 @@ layer(base);
 @layer utilities {
     /* Extra small breakpoint utility classes */
     @media (max-width: 475px) {
-        .xs\:text-xs { font-size: 0.75rem; line-height: 1rem; }
-        .xs\:text-sm { font-size: 0.875rem; line-height: 1.25rem; }
-        .xs\:p-1 { padding: 0.25rem; }
-        .xs\:p-2 { padding: 0.5rem; }
-        .xs\:px-1 { padding-left: 0.25rem; padding-right: 0.25rem; }
-        .xs\:py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-        .xs\:gap-1 { gap: 0.25rem; }
-        .xs\:gap-2 { gap: 0.5rem; }
-        .xs\:inline { display: inline; }
-        .xs\:hidden { display: none; }
-        .xs\:w-6 { width: 1.5rem; }
-        .xs\:h-6 { height: 1.5rem; }
-        .xs\:w-8 { width: 2rem; }
-        .xs\:h-8 { height: 2rem; }
-        .xs\:min-w-\[240px\] { min-width: 240px; }
+        .xs\:text-xs {
+            font-size: 0.75rem;
+            line-height: 1rem;
+        }
+        .xs\:text-sm {
+            font-size: 0.875rem;
+            line-height: 1.25rem;
+        }
+        .xs\:p-1 {
+            padding: 0.25rem;
+        }
+        .xs\:p-2 {
+            padding: 0.5rem;
+        }
+        .xs\:px-1 {
+            padding-left: 0.25rem;
+            padding-right: 0.25rem;
+        }
+        .xs\:py-1 {
+            padding-top: 0.25rem;
+            padding-bottom: 0.25rem;
+        }
+        .xs\:gap-1 {
+            gap: 0.25rem;
+        }
+        .xs\:gap-2 {
+            gap: 0.5rem;
+        }
+        .xs\:inline {
+            display: inline;
+        }
+        .xs\:hidden {
+            display: none;
+        }
+        .xs\:w-6 {
+            width: 1.5rem;
+        }
+        .xs\:h-6 {
+            height: 1.5rem;
+        }
+        .xs\:w-8 {
+            width: 2rem;
+        }
+        .xs\:h-8 {
+            height: 2rem;
+        }
+        .xs\:min-w-\[240px\] {
+            min-width: 240px;
+        }
     }
 
     /* Prevent horizontal scrolling on mobile */
     .prevent-horizontal-scroll {
         overflow-x: hidden;
         max-width: 100vw;
-    }    /* Grid cell responsive sizing for game grid (smaller on mobile) */
+    } /* Grid cell responsive sizing for game grid (smaller on mobile) */
     .grid-cell-mobile {
         width: 28px;
         height: 28px;
@@ -345,6 +282,15 @@ layer(base);
         background: hsl(var(--border) / 0.8);
     }
 
+    .app-header {
+        backdrop-filter: blur(6px);
+        background: linear-gradient(
+            to bottom,
+            hsl(var(--background) / 0.9),
+            hsl(var(--background) / 0.7)
+        );
+    }
+
     /* Better focus styles for mobile */
     .mobile-focus:focus-visible {
         outline: 2px solid hsl(var(--ring));
@@ -354,10 +300,14 @@ layer(base);
 
 /* Improve touch interactions */
 @media (pointer: coarse) {
-    button, [role="button"], input, select, textarea {
+    button,
+    [role='button'],
+    input,
+    select,
+    textarea {
         min-height: 44px;
     }
-    
+
     /* Larger click targets for grid cells on touch devices */
     .grid-cell {
         min-height: 36px;


### PR DESCRIPTION
## Summary
- wrap app with new `Layout` featuring Header and Footer
- reorganize Calculator page into a two-column layout
- keep probability results sticky on larger screens

## Testing
- `yarn test-once` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdfe4860083299f9b158c7d2c3127